### PR TITLE
Set the request timeout to 90s

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn app:app
+web: gunicorn app:app --timeout 90


### PR DESCRIPTION
Try to fix 

```
at=error code=H13 desc="Connection closed without response" method=POST path="/api/handle-upload" host=trip-carbon-calculator.herokuapp.com request_id=105ab7dd-7062-485a-8bd8-8f87773a73f8 fwd="207.81.85.45" dyno=web.1 connect=0ms service=30058ms status=503 bytes=0 protocol=https
```